### PR TITLE
add basic auth capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,12 @@ Usage of grafana-ntfy:
         Allow insecure connections to ntfy-url
   -ntfy-url string
         The ntfy url including the topic. e.g.: https://ntfy.sh/mytopic
+  -password string
+        The ntfy password
   -port int
         The port to listen on (default 8080)
+  -username string
+        The ntfy username
 ```
 
 # No https?

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -15,6 +15,8 @@ import (
 
 var (
 	ntfyUrl       = flag.String("ntfy-url", "", "The ntfy url including the topic. e.g.: https://ntfy.sh/mytopic")
+	username      = flag.String("username", "", "The ntfy username")
+	password      = flag.String("password", "", "The ntfy password")
 	allowInsecure = flag.Bool("allow-insecure", false, "Allow insecure connections to ntfy-url")
 	port          = flag.Int("port", 8080, "The port to listen on")
 )
@@ -159,6 +161,11 @@ func sendNotification(payload NtfyNotification) error {
 
 	// Set the content type to json
 	req.Header.Set("Content-Type", "application/json")
+
+	// Add auth if provided
+	if *username != "" && *password != "" {
+		req.SetBasicAuth(*username, *password)
+	}
 
 	// Send the request
 	defer req.Body.Close()


### PR DESCRIPTION
I had to setup my own ntfy server which requires basic auth: https://docs.ntfy.sh/config/#example-private-instance

I just did some little changes to enable the possiblity to provide a username and a password